### PR TITLE
Add Unary Operator

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -12,8 +12,8 @@ use crate::parser::expr::{
     Assignment, Binary, Block, BoolLiteral, Call, CallStruct, ConstDecl, EnumDecl, Expr,
     FloatLiteral, FnDecl, GetProp, GetStaticProp, Grouping, If, ImplDecl, IntLiteral, Lambda, Loop,
     Match, NilLiteral, Return, SelfStatic, Self_, SetIndex, SetProp, Stmt, StrLiteral, StructDecl,
-    Unary, ValType, VarDecl, Variable, VecIndex, Vec_, TYPE_BOOL, TYPE_FUNC, TYPE_INT, TYPE_NUM,
-    TYPE_STR, TYPE_STRUCT, TYPE_VEC,
+    Unary, UnaryOperator, ValType, VarDecl, Variable, VecIndex, Vec_, TYPE_BOOL, TYPE_FUNC,
+    TYPE_INT, TYPE_NUM, TYPE_STR, TYPE_STRUCT, TYPE_VEC,
 };
 
 use self::env::{Env, EnvVal};
@@ -465,32 +465,36 @@ impl Interpreter {
     fn eval_unary_expr(&mut self, expr: &Unary) -> Result<Val> {
         let un_expr: Val = self.evaluate(&expr.expr)?;
 
-        let val = match expr.operator.token_type {
-            TokenType::Bang => match un_expr {
+        let val = match expr.operator {
+            UnaryOperator::Not => match un_expr {
                 Val::Bool(b) => Val::Bool(!b),
                 val => {
-                    return Err(RuntimeError::from_token(
-                        expr.operator.clone(),
-                        format!("Expected \"bool\" value, got \"{}\"", val.get_type()),
-                    ))
+                    return Err(RuntimeError::new(format!(
+                        "Expected \"bool\" value, got \"{}\"",
+                        val.get_type()
+                    )))
                 }
             },
-            TokenType::Minus => match un_expr {
+            UnaryOperator::Sub => match un_expr {
                 Val::Float(n) => Val::Float(-n),
                 Val::Int(n) => Val::Int(-n),
                 val => {
-                    return Err(RuntimeError::from_token(
-                        expr.operator.clone(),
-                        format!("Expected \"num\" value, got \"{}\"", val.get_type()),
-                    ))
+                    return Err(RuntimeError::new(format!(
+                        "Expected \"num\" value, got \"{}\"",
+                        val.get_type()
+                    )))
                 }
             },
-            _ => {
-                return Err(RuntimeError::from_token(
-                    expr.operator.clone(),
-                    format!("Unknown unary \"{}\"", expr.operator.lexeme),
-                ))
-            }
+            UnaryOperator::Add => match un_expr {
+                Val::Float(n) => Val::Float(n),
+                Val::Int(n) => Val::Int(n),
+                val => {
+                    return Err(RuntimeError::new(format!(
+                        "Expected \"num\" value, got \"{}\"",
+                        val.get_type()
+                    )))
+                }
+            },
         };
 
         Ok(val)

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1,6 +1,7 @@
 use crate::interpreter::val::Val;
 use crate::lexer::token::TokenType;
 use crate::Token;
+use std::convert::TryFrom;
 use std::fmt;
 
 #[derive(Debug, Clone)]
@@ -193,9 +194,16 @@ pub struct FloatLiteral(pub f64);
 pub struct StrLiteral(pub String);
 
 #[derive(Debug, Clone)]
+pub enum UnaryOperator {
+    Add,
+    Sub,
+    Not,
+}
+
+#[derive(Debug, Clone)]
 pub struct Unary {
     pub expr: Box<Expr>,
-    pub operator: Token,
+    pub operator: UnaryOperator,
 }
 
 #[derive(Debug, Clone)]
@@ -397,7 +405,7 @@ impl Binary {
 }
 
 impl Unary {
-    pub fn new(expr: Box<Expr>, operator: Token) -> Self {
+    pub fn new(expr: Box<Expr>, operator: UnaryOperator) -> Self {
         Self { expr, operator }
     }
 }
@@ -620,5 +628,18 @@ impl Match {
 impl MatchArm {
     pub fn new(expr: Box<Expr>, body: Box<Expr>) -> Self {
         Self { expr, body }
+    }
+}
+
+impl TryFrom<&Token> for UnaryOperator {
+    type Error = ();
+
+    fn try_from(token: &Token) -> Result<Self, Self::Error> {
+        match token.token_type {
+            TokenType::Plus => Ok(UnaryOperator::Add),
+            TokenType::Minus => Ok(UnaryOperator::Sub),
+            TokenType::Bang => Ok(UnaryOperator::Not),
+            _ => Err(()),
+        }
     }
 }


### PR DESCRIPTION
- Introduce `enum UnaryOperator` in parser/mod.rs, and update the existing `UnaryExpression` structure to use `UnaryOperator`.
- Update the implementation in interpreter(`eval_unary_expr`) to use the new `UnaryOperator`.
- Update the parser (`unary_expr`) to accomodate unary addition operation (Ex: `+1`).