### PR TITLE
Move struct/enum name collision check to interpreter

### DIFF
--- a/src/interpreter/env.rs
+++ b/src/interpreter/env.rs
@@ -334,6 +334,10 @@ impl Env {
         );
     }
 
+    pub fn contains_key(&self, name: &str) -> bool {
+        self.vals.contains_key(name)
+    }
+
     pub fn define_struct(&mut self, struct_: Struct) {
         self.vals.insert(
             struct_.name.clone(),
@@ -379,7 +383,7 @@ impl Env {
         if self.vals.contains_key(&func.get_name()) {
             return Err(RuntimeError::from_token(
                 func.name.clone(),
-                format!("Trying to redefine function \"{}\"", func.get_name()),
+                format!("Name \"{}\" is already in use", func.get_name()),
             ));
         }
 

--- a/src/interpreter/env.rs
+++ b/src/interpreter/env.rs
@@ -334,7 +334,7 @@ impl Env {
         );
     }
 
-    pub fn contains_key(&self, name: &str) -> bool {
+    pub fn has_definition(&self, name: &str) -> bool {
         self.vals.contains_key(name)
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -66,7 +66,7 @@ impl Interpreter {
     }
 
     fn eval_enum_stmt(&mut self, stmt: &EnumDecl) -> Result<StmtVal> {
-        if self.env.borrow().contains_key(&stmt.name.lexeme) {
+        if self.env.borrow().has_definition(&stmt.name.lexeme) {
             return Err(RuntimeError::from_token(
                 stmt.name.clone(),
                 format!("Name '{}' is already in use", stmt.name.lexeme),
@@ -93,7 +93,7 @@ impl Interpreter {
     }
 
     fn eval_struct_stmt(&mut self, stmt: &StructDecl) -> Result<StmtVal> {
-        if self.env.borrow().contains_key(&stmt.name.lexeme) {
+        if self.env.borrow().has_definition(&stmt.name.lexeme) {
             return Err(RuntimeError::from_token(
                 stmt.name.clone(),
                 format!("Name '{}' is already in use", stmt.name.lexeme),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -65,7 +65,13 @@ impl Interpreter {
         Ok(())
     }
 
-    fn eval_enum_stmt(&mut self, stmt: &EnumDecl) -> StmtVal {
+    fn eval_enum_stmt(&mut self, stmt: &EnumDecl) -> Result<StmtVal> {
+        if self.env.borrow().contains_key(&stmt.name.lexeme) {
+            return Err(RuntimeError::from_token(
+                stmt.name.clone(),
+                format!("Name '{}' is already in use", stmt.name.lexeme),
+            ));
+        }
         for (val, name) in stmt.vals.iter().enumerate() {
             let val_name_t = name.clone();
             let name_t = stmt.name.clone();
@@ -83,10 +89,16 @@ impl Interpreter {
 
         self.env.borrow_mut().define_enum(enum_);
 
-        StmtVal::None
+        Ok(StmtVal::None)
     }
 
-    fn eval_struct_stmt(&mut self, stmt: &StructDecl) -> StmtVal {
+    fn eval_struct_stmt(&mut self, stmt: &StructDecl) -> Result<StmtVal> {
+        if self.env.borrow().contains_key(&stmt.name.lexeme) {
+            return Err(RuntimeError::from_token(
+                stmt.name.clone(),
+                format!("Name '{}' is already in use", stmt.name.lexeme),
+            ));
+        }
         let decl = stmt.clone();
         let struct_ = env::Struct::new(
             stmt.name.lexeme.clone(),
@@ -138,7 +150,7 @@ impl Interpreter {
 
         self.env.borrow_mut().define_struct(struct_);
 
-        StmtVal::None
+        Ok(StmtVal::None)
     }
 
     fn eval_impl_stmt(&mut self, stmt: &ImplDecl) -> Result<StmtVal> {
@@ -1194,8 +1206,8 @@ impl Interpreter {
             IfStmt(if_stmt) => self.eval_if_stmt(if_stmt),
             Fn(f_decl) => self.eval_fn_stmt(f_decl),
             LoopStmt(loop_stmt) => self.eval_loop_stmt(loop_stmt),
-            Enum(enum_decl) => Ok(self.eval_enum_stmt(enum_decl)),
-            Struct(struct_decl) => Ok(self.eval_struct_stmt(struct_decl)),
+            Enum(enum_decl) => self.eval_enum_stmt(enum_decl),
+            Struct(struct_decl) => self.eval_struct_stmt(struct_decl),
             Impl(impl_decl) => self.eval_impl_stmt(impl_decl),
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -254,7 +254,6 @@ impl Parser {
     /// Parses the enum declaration statement.
     fn enum_decl(&mut self) -> Result<Stmt> {
         let name: Token = self.consume(TokenType::Identifier, "Enum name expected")?;
-        self.check_if_declared(&name)?;
         self.consume(
             TokenType::LeftCurlyBrace,
             "Curly brace \"{\" expected after enum name",
@@ -309,7 +308,6 @@ impl Parser {
     /// whether they are `pub` and their type
     fn struct_decl(&mut self) -> Result<Stmt> {
         let name: Token = self.consume(TokenType::Identifier, "Struct name expected")?;
-        self.check_if_declared(&name)?;
         self.consume(
             TokenType::LeftCurlyBrace,
             "Curly brace \"{\" expected after struct name",
@@ -1401,17 +1399,6 @@ impl Parser {
         }
 
         Ok(self.advance().clone())
-    }
-
-    fn check_if_declared(&mut self, name: &Token) -> Result<()> {
-        if self.structs.contains(&name.lexeme) {
-            self.err = true;
-            let msg = format!("Name \"{}\" is already in use", name.lexeme);
-            error_token(&name, &msg);
-            Err(ParserError)
-        } else {
-            Ok(())
-        }
     }
 
     fn try_to_recover(&mut self) {


### PR DESCRIPTION
This PR moves struct/enum name collision checks from parser to interpreter, as discussed in #6